### PR TITLE
Upgrades to AoC Recurring task

### DIFF
--- a/tasks/aoc.ts
+++ b/tasks/aoc.ts
@@ -16,7 +16,7 @@ export default (async (client: Client) => {
     }
 
     const content = now.day == 26 ? `Final Results of AoC ${now.year}` : ``;
-    const embed = await embedLeaderboard(get("id", "aoc") as number, get("year", "aoc") as number);
+    const embed = await embedLeaderboard(get("id", "aoc") as number, get(now.year+"", "aoc") as number);
     const channel = await client.channels.fetch(get('announcement_channel', 'config') as string) as TextChannel;
     await channel.send({ content: content, embeds: [embed] });
 }) as TaskExecutor

--- a/tasks/aoc.ts
+++ b/tasks/aoc.ts
@@ -1,10 +1,22 @@
-import {Client, TextChannel} from "discord.js";
+import {Client, EmbedBuilder, TextChannel} from "discord.js";
 import {TaskExecutor} from "../types";
 import {embedLeaderboard} from "../lib/aocleaderboardparser"
 import {get} from "../lib/configmanager";
+import {DateTime} from "luxon";
 
 export default (async (client: Client) => {
+    const now = DateTime.now().setZone("Europe/Berlin");
+    if (now.month == 11 && now.day == 30) {
+        const channel = await client.channels.fetch(get('announcement_channel', 'config') as string) as TextChannel;
+        await channel.send({ content: `:star: Advent of Code ${now.year} starts tomorrow :star2:`});
+        return;
+    }
+    if (now.month != 12 || now.day > 26) {
+        return;
+    }
+
+    const content = now.day == 26 ? `Final Results of AoC ${now.year}` : ``;
     const embed = await embedLeaderboard(get("id", "aoc") as number, get("year", "aoc") as number);
     const channel = await client.channels.fetch(get('announcement_channel', 'config') as string) as TextChannel;
-    await channel.send({ embeds: [embed] });
+    await channel.send({ content: content, embeds: [embed] });
 }) as TaskExecutor


### PR DESCRIPTION
Added the following Features to the Advent of Code Recurring Task:

- It only posts the leaderboard in December and till the 25th of December, so there is no need to turn it of after and it will automatically reactivate for next years challange
- Automatically gets the current year, so the only thing that will need to get adjusted in the congif is the token for the private leaderboard
- Print final results on the 26th of december
- Print an announcement on the last day of november 