### PR TITLE
Replace reviewdog with another report viewer thats working

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -16,7 +16,8 @@ jobs:
       - run: yarn lint --output-file eslint_report.json --format json
         continue-on-error: true
       - name: Annotate code linting results
-        uses: ataylorme/eslint-annotate-action@1.0.4
+        uses: ataylorme/eslint-annotate-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: "eslint_report.json"
+          fail-on-warning: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: reviewdog/action-eslint@v1
+      - name: Setup node
+        uses: actions/setup-node@v3
+      - run: yarn install --dev
+      - run: yarn lint --output-file eslint_report.json --format json
+        continue-on-error: true
+      - name: Annotate code linting results
+        uses: ataylorme/eslint-annotate-action@1.0.4
         with:
-          reporter: github-check
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          report-json: "eslint_report.json"

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ const INTENTS = [
     IntentsBitField.Flags.GuildMessages,
     IntentsBitField.Flags.Guilds,
     IntentsBitField.Flags.GuildMessageReactions
-];
+]
 
 const client = new Client({intents: INTENTS});
 

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ const INTENTS = [
     IntentsBitField.Flags.GuildMessages,
     IntentsBitField.Flags.Guilds,
     IntentsBitField.Flags.GuildMessageReactions
-]
+];
 
 const client = new Client({intents: INTENTS});
 


### PR DESCRIPTION
Our CI in dependabot's PRs and on master are currently failing, because reviewdog decided to spontaneously stop working. This PR replaces reviewdog with another report viewer to view our eslint results.