### PR TITLE
Write all attendance blocks straight to file, even if no people are attending

### DIFF
--- a/lib/configmanager.ts
+++ b/lib/configmanager.ts
@@ -89,6 +89,7 @@ export async function writeConfigFile(path: string, content: string): Promise<vo
  */
 export function get(key: string, config: string): unknown {
     if(configs[config] === undefined) throw new ReferenceError(`Config ${config} doesn't exist`);
+    if (configs[config][key] === undefined) return undefined;
     return JSON.parse(JSON.stringify(configs[config][key]) || "{}");
 }
 

--- a/modules/attendancetracker/attendanceTrackerTask.ts
+++ b/modules/attendancetracker/attendanceTrackerTask.ts
@@ -3,7 +3,7 @@ import { get } from "../../lib/configmanager";
 import { Weekday } from "../../lib/tasks/recurringtask";
 import {TaskExecutor} from "../../types";
 import {buildAttendanceAction, buildTimeTableEmbed} from "./attendanceTrackerVisuals";
-import {getBlocks, resetAttendance} from "./attendanceTracker";
+import {getBlocks, resetAttendance, writeAllBlocksToAttendanceFile} from "./attendanceTracker";
 
 /**
  * TaskExecutor for printing the timetable with attendance buttons of the given weekday <br>
@@ -15,6 +15,7 @@ export default (async (client: Client, weekday: Weekday) => {
     resetAttendance();
     const channel = await client.channels.fetch(get('announcement_channel', 'config') as string) as TextChannel;
     const blocks = getBlocks(weekday, true);
+    await writeAllBlocksToAttendanceFile(weekday, blocks);
     await channel.send({embeds: [buildTimeTableEmbed(blocks, weekday)],
                         components: buildAttendanceAction(blocks)});
 }) as TaskExecutor;

--- a/modules/attendancetracker/attendanceTrackerVisuals.ts
+++ b/modules/attendancetracker/attendanceTrackerVisuals.ts
@@ -47,7 +47,7 @@ export function buildAttendanceAction(blocks: CalendarBlock[]) : ActionRowBuilde
                 new ButtonBuilder()
                     .setLabel(block.title)
                     .setCustomId("attendancetracker-" + block.weekday + "-"
-                        + block.title.toLowerCase().replace(" ", "_"))
+                        + block.title.toLowerCase().replace(/\s/g, "_"))
                     .setStyle(ButtonStyle.Primary)
             );
         }


### PR DESCRIPTION
This PR adds functionality that automatically writes all blocks to the stat file, even if noone attends them. It also changes the format to only use the date without any time as the config key, since (milli)seconds were an issue in the past.

There are also some minor fixes included in the PR:
- Correctly replacing _all_ whitespace from the block title when writing to a file
- The config manager correctly returns `undefined` if a key isn't found in a config, instead of an empty object (`{}`)