### PR TITLE
Fix Mensa Parser

### DIFF
--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -8,7 +8,6 @@ import mensaCommand from "../modules/mensa/mensaCommand";
 import truthtableCommand from "../modules/truthtable/truthtableCommand";
 import voteCommand from "../modules/vote/voteCommand";
 
-import mensaTask from "../modules/mensa/mensaTask";
 import aocTask from "../modules/aoc/aocTask";
 import attendanceTrackerTask from "../modules/attendancetracker/attendanceTrackerTask";
 import koeriSelectionMenu from "../modules/koeri/koeriSelectionMenuListener";
@@ -21,12 +20,14 @@ export const SLASH_COMMANDS: ISlashCommand[] = [
 
 export const TASKS = [
     // Mensa-Plans
-    new UniversityDayRecurringTask(Weekday.MONDAY, 9, 48, mensaTask),
-    new UniversityDayRecurringTask(Weekday.TUESDAY, 9, 48, mensaTask),
-    new UniversityDayRecurringTask(Weekday.WEDNESDAY, 9, 48, mensaTask),
-    new UniversityDayRecurringTask(Weekday.THURSDAY, 9, 48, mensaTask),
-    new UniversityDayRecurringTask(Weekday.FRIDAY, 9, 48, mensaTask),
 
+    /*
+     * new UniversityDayRecurringTask(Weekday.MONDAY, 9, 48, mensaTask),
+     * new UniversityDayRecurringTask(Weekday.TUESDAY, 9, 48, mensaTask),
+     * new UniversityDayRecurringTask(Weekday.WEDNESDAY, 9, 48, mensaTask),
+     * new UniversityDayRecurringTask(Weekday.THURSDAY, 9, 48, mensaTask),
+     * new UniversityDayRecurringTask(Weekday.FRIDAY, 9, 48, mensaTask),
+     */
 
     // Advent of Code
     new RecurringTask(Weekday.MONDAY, 22, 5, aocTask),


### PR DESCRIPTION
The mensa parser is currently crashing our bot daily. This is due to the underlying library, `ka-mensa-fetch`, currently being unable to fetch mensa data, most likely since the website changed in some way. Fixing the underlying issue in the library is not feasable for us right now, and hoping for a library fix seems unlikely aswell, since the last release was several months ago, and the latest commits were only dependency updates.

This PR currently just disables the mensa plan, as a quick fix. We can also use this PR to discuss the future of the mensa feature, since I'm currently unsure if we still need/want to support it, and how we should go about fixing it.

@Kr0nox @ProgramPhoenix